### PR TITLE
fix galactic compilation with missing include for `usleep`

### DIFF
--- a/explore/src/costmap_client.cpp
+++ b/explore/src/costmap_client.cpp
@@ -40,6 +40,7 @@
 #include <functional>
 #include <mutex>
 #include <string>
+#include <unistd.h>
 
 namespace explore
 {


### PR DESCRIPTION
I don't expect this to break foxy.