### PR TITLE
Fix missing dependencies

### DIFF
--- a/explore/package.xml
+++ b/explore/package.xml
@@ -14,17 +14,18 @@
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
-  <depend>rclcpp</depend>
-  <depend>std_msgs</depend>
-  <depend>sensor_msgs</depend>
-
-  <depend>tf2</depend>
-  <depend>tf2_ros</depend>
-  <depend>tf2_geometry_msgs</depend>
-  <depend>nav_msgs</depend>
+  <depend>ament_cmake</depend>
   <depend>map_msgs</depend>
+  <depend>nav2_costmap_2d</depend>
+  <depend>nav2_msgs</depend>
+  <depend>nav_msgs</depend>
+  <depend>rclcpp</depend>
+  <depend>sensor_msgs</depend>
+  <depend>std_msgs</depend>
+  <depend>tf2</depend>
+  <depend>tf2_geometry_msgs</depend>
+  <depend>tf2_ros</depend>
   <depend>visualization_msgs</depend>
-
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
They are 'find_package'-ed in the CMakeLists.txt but not listed as dependency

As per request: https://github.com/robo-friends/m-explore-ros2/pull/5#issuecomment-965764431