### PR TITLE
Fix compilation on Jazzy

### DIFF
--- a/explore/src/explore.cpp
+++ b/explore/src/explore.cpp
@@ -127,7 +127,7 @@ Explore::Explore()
       std::chrono::milliseconds((uint16_t)(1000.0 / planner_frequency_)),
       [this]() { makePlan(); });
   // Start exploration right away
-  exploring_timer_->execute_callback();
+  makePlan();
 }
 
 Explore::~Explore()
@@ -411,7 +411,7 @@ void Explore::resume()
   // Reactivate the timer
   exploring_timer_->reset();
   // Resume immediately
-  exploring_timer_->execute_callback();
+  makePlan();
 }
 
 }  // namespace explore


### PR DESCRIPTION
The `execute_callback();` has a different syntax now. So to keep backward compatibility I just call the function itself.