### PR TITLE
Replace custom logger by node logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@ This forks implemennts little changes to integrate m-explore in a benchmarking s
 Changes:
 - Added a publisher to the `/goal_sent` topic when sending a goal to nav2, 
   so that the benchmarking suite can easily track the goals sent by the exploration algorithm.
+- Added a publisher to the `/goal_reached` topic to track when the robot reaches a goal or when the exploration is stopped.
 - Edited the default explore params
 - Fixed some headers to avoid warnings.
+- Fixed the initialization of the frontier size (see [prina404's repo](https://github.com/prina404/m-explore/commit/4d2e9f34c0fc01d90cb81fbe51545fff22f9d0c9))
 
 ROS2 package port for multi-robot autonomous exploration of [m-explore](https://github.com/hrnr/m-explore). Currently tested on Eloquent, Dashing, Foxy, and Galactic distros.
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,41 @@
 # m-explore ROS2 port
 
+## Fork status:
+
+This forks implemennts little changes to integrate m-explore in a benchmarking suite project.
+
+Changes:
+- Added a publisher to the `/goal_sent` topic when sending a goal to nav2, 
+  so that the benchmarking suite can easily track the goals sent by the exploration algorithm.
+- Edited the default explore params
+- Fixed some headers to avoid warnings.
+
 ROS2 package port for multi-robot autonomous exploration of [m-explore](https://github.com/hrnr/m-explore). Currently tested on Eloquent, Dashing, Foxy, and Galactic distros.
 
 ### Contents
-1. [Autonomous exploration](#Autonomous-exploration)
-    * [Demo in simulation with a TB3 robot](#Simulation-with-a-TB3-robot)    
-    * [Demo with a JetBot](#On-a-JetBot-with-realsense-cameras)
-    * [Instructions for the simulation demo](#Running-the-explore-demo-with-TB3)    
-2. [Multirobot map merge](#Multirobot-map-merge)
-    * [Simulation demo with known initial poses](#Known-initial-poses)
-    * [Simulation demo with unknown initial poses](#Unknown-initial-poses)
-    * [ROS2 requirements](#ROS2-requirements)
-    * [Instructions for simulation demos](#Running-the-demo-with-TB3)
+- [Fork status:](#fork-status)
+  - [Contents](#contents)
+- [Autonomous exploration](#autonomous-exploration)
+  - [Simulation with a TB3 robot](#simulation-with-a-tb3-robot)
+  - [On a JetBot with realsense cameras](#on-a-jetbot-with-realsense-cameras)
+- [Installing](#installing)
+- [Building](#building)
+- [RUNNING](#running)
+  - [Running the explore demo with TB3](#running-the-explore-demo-with-tb3)
+  - [Additional features](#additional-features)
+    - [Stop/Resume exploration](#stopresume-exploration)
+    - [Returning to initial pose](#returning-to-initial-pose)
+    - [TB3 troubleshooting (with foxy)](#tb3-troubleshooting-with-foxy)
+- [Multirobot map merge](#multirobot-map-merge)
+  - [Known initial poses](#known-initial-poses)
+  - [Unknown initial poses](#unknown-initial-poses)
+  - [ROS2 requirements](#ros2-requirements)
+    - [SLAM](#slam)
+    - [Nav2 gazebo spawner (deprecated in humble)](#nav2-gazebo-spawner-deprecated-in-humble)
+    - [Nav2 config files](#nav2-config-files)
+  - [Running the demo with TB3](#running-the-demo-with-tb3)
+- [WIKI](#wiki)
+- [COPYRIGHT](#copyright)
 
 ## Autonomous exploration
 

--- a/explore/config/params.yaml
+++ b/explore/config/params.yaml
@@ -2,13 +2,13 @@
   ros__parameters:
     robot_base_frame: base_link
     return_to_init: true
-    costmap_topic: map
-    costmap_updates_topic: map_updates
+    costmap_topic: /map
+    costmap_updates_topic: /map_updates
     visualize: true
     planner_frequency: 0.15
-    progress_timeout: 30.0
-    potential_scale: 3.0
-    orientation_scale: 0.0
-    gain_scale: 1.0
+    progress_timeout: 30.0 # Maybe too low, the planner is sometime really slow
+    potential_scale: 3.0 # TODO: adjust
+    orientation_scale: 0.0 # Not used
+    gain_scale: 1.0 # TODO: adjust
     transform_tolerance: 0.3
     min_frontier_size: 0.75

--- a/explore/include/explore/explore.h
+++ b/explore/include/explore/explore.h
@@ -68,79 +68,81 @@ using namespace std::placeholders;
 #endif
 namespace explore
 {
-/**
- * @class Explore
- * @brief A class adhering to the robot_actions::Action interface that moves the
- * robot base to explore its environment.
- */
-class Explore : public rclcpp::Node
-{
-public:
-  Explore();
-  ~Explore();
+    /**
+     * @class Explore
+     * @brief A class adhering to the robot_actions::Action interface that moves the
+     * robot base to explore its environment.
+     */
+    class Explore : public rclcpp::Node
+    {
+    public:
+        Explore();
+        ~Explore();
 
-  void start();
-  void stop(bool finished_exploring = false);
-  void resume();
+        void start();
+        void stop(bool finished_exploring = false);
+        void resume();
 
-  using NavigationGoalHandle =
-      rclcpp_action::ClientGoalHandle<nav2_msgs::action::NavigateToPose>;
+        using NavigationGoalHandle =
+            rclcpp_action::ClientGoalHandle<nav2_msgs::action::NavigateToPose>;
 
-private:
-  /**
-   * @brief  Make a global plan
-   */
-  void makePlan();
+    private:
+        /**
+         * @brief  Make a global plan
+         */
+        void makePlan();
 
-  // /**
-  //  * @brief  Publish a frontiers as markers
-  //  */
-  void visualizeFrontiers(
-      const std::vector<frontier_exploration::Frontier>& frontiers);
+        // /**
+        //  * @brief  Publish a frontiers as markers
+        //  */
+        void visualizeFrontiers(
+            const std::vector<frontier_exploration::Frontier>& frontiers);
 
-  bool goalOnBlacklist(const geometry_msgs::msg::Point& goal);
+        bool goalOnBlacklist(const geometry_msgs::msg::Point& goal);
 
-  NavigationGoalHandle::SharedPtr navigation_goal_handle_;
-  // void
-  // goal_response_callback(std::shared_future<NavigationGoalHandle::SharedPtr>
-  // future);
-  void reachedGoal(const NavigationGoalHandle::WrappedResult& result,
-                   const geometry_msgs::msg::Point& frontier_goal);
+        NavigationGoalHandle::SharedPtr navigation_goal_handle_;
+        // void
+        // goal_response_callback(std::shared_future<NavigationGoalHandle::SharedPtr>
+        // future);
+        void reachedGoal(const NavigationGoalHandle::WrappedResult& result,
+            const geometry_msgs::msg::Point& frontier_goal);
 
-  rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr
-      marker_array_publisher_;
-  rclcpp::Logger logger_ = rclcpp::get_logger("ExploreNode");
-  tf2_ros::Buffer tf_buffer_;
-  tf2_ros::TransformListener tf_listener_;
+        // Publisher for the goal_sent topic
+        rclcpp::Publisher<geometry_msgs::msg::Point>::SharedPtr goal_sent_publisher_;
+        rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr
+            marker_array_publisher_;
+        rclcpp::Logger logger_ = rclcpp::get_logger("ExploreNode");
+        tf2_ros::Buffer tf_buffer_;
+        tf2_ros::TransformListener tf_listener_;
 
-  Costmap2DClient costmap_client_;
-  rclcpp_action::Client<nav2_msgs::action::NavigateToPose>::SharedPtr
-      move_base_client_;
-  frontier_exploration::FrontierSearch search_;
-  rclcpp::TimerBase::SharedPtr exploring_timer_;
-  // rclcpp::TimerBase::SharedPtr oneshot_;
+        Costmap2DClient costmap_client_;
+        rclcpp_action::Client<nav2_msgs::action::NavigateToPose>::SharedPtr
+            move_base_client_;
+        frontier_exploration::FrontierSearch search_;
+        rclcpp::TimerBase::SharedPtr exploring_timer_;
+        // rclcpp::TimerBase::SharedPtr oneshot_;
 
-  rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr resume_subscription_;
-  void resumeCallback(const std_msgs::msg::Bool::SharedPtr msg);
+        rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr resume_subscription_;
+        void resumeCallback(const std_msgs::msg::Bool::SharedPtr msg);
 
-  std::vector<geometry_msgs::msg::Point> frontier_blacklist_;
-  geometry_msgs::msg::Point prev_goal_;
-  double prev_distance_;
-  rclcpp::Time last_progress_;
-  size_t last_markers_count_;
+        std::vector<geometry_msgs::msg::Point> frontier_blacklist_;
+        geometry_msgs::msg::Point prev_goal_;
+        double prev_distance_;
+        rclcpp::Time last_progress_;
+        size_t last_markers_count_;
 
-  geometry_msgs::msg::Pose initial_pose_;
-  void returnToInitialPose(void);
+        geometry_msgs::msg::Pose initial_pose_;
+        void returnToInitialPose(void);
 
-  // parameters
-  double planner_frequency_;
-  double potential_scale_, orientation_scale_, gain_scale_;
-  double progress_timeout_;
-  bool visualize_;
-  bool return_to_init_;
-  std::string robot_base_frame_;
-  bool resuming_ = false;
-};
+        // parameters
+        double planner_frequency_;
+        double potential_scale_, orientation_scale_, gain_scale_;
+        double progress_timeout_;
+        bool visualize_;
+        bool return_to_init_;
+        std::string robot_base_frame_;
+        bool resuming_ = false;
+    };
 }  // namespace explore
 
 #endif

--- a/explore/include/explore/explore.h
+++ b/explore/include/explore/explore.h
@@ -109,6 +109,9 @@ namespace explore
 
         // Publisher for the goal_sent topic
         rclcpp::Publisher<geometry_msgs::msg::Point>::SharedPtr goal_sent_publisher_;
+        // Publisher for the goal_reached topic
+        rclcpp::Publisher<geometry_msgs::msg::Point>::SharedPtr goal_reached_publisher_;
+
         rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr
             marker_array_publisher_;
         rclcpp::Logger logger_ = rclcpp::get_logger("ExploreNode");

--- a/explore/include/explore/explore.h
+++ b/explore/include/explore/explore.h
@@ -114,7 +114,6 @@ namespace explore
 
         rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr
             marker_array_publisher_;
-        rclcpp::Logger logger_ = rclcpp::get_logger("ExploreNode");
         tf2_ros::Buffer tf_buffer_;
         tf2_ros::TransformListener tf_listener_;
 

--- a/explore/include/explore/frontier_search.h
+++ b/explore/include/explore/frontier_search.h
@@ -5,84 +5,85 @@
 
 namespace frontier_exploration
 {
-/**
- * @brief Represents a frontier
- *
- */
-struct Frontier {
-  std::uint32_t size;
-  double min_distance;
-  double cost;
-  geometry_msgs::msg::Point initial;
-  geometry_msgs::msg::Point centroid;
-  geometry_msgs::msg::Point middle;
-  std::vector<geometry_msgs::msg::Point> points;
-};
-
-/**
- * @brief Thread-safe implementation of a frontier-search task for an input
- * costmap.
- */
-class FrontierSearch
-{
-public:
-  FrontierSearch()
-  {
-  }
-
   /**
-   * @brief Constructor for search task
-   * @param costmap Reference to costmap data to search.
-   */
-  FrontierSearch(nav2_costmap_2d::Costmap2D* costmap, double potential_scale,
-                 double gain_scale, double min_frontier_size);
-
-  /**
-   * @brief Runs search implementation, outward from the start position
-   * @param position Initial position to search from
-   * @return List of frontiers, if any
-   */
-  std::vector<Frontier> searchFrom(geometry_msgs::msg::Point position);
-
-protected:
-  /**
-   * @brief Starting from an initial cell, build a frontier from valid adjacent
-   * cells
-   * @param initial_cell Index of cell to start frontier building
-   * @param reference Reference index to calculate position from
-   * @param frontier_flag Flag vector indicating which cells are already marked
-   * as frontiers
-   * @return new frontier
-   */
-  Frontier buildNewFrontier(unsigned int initial_cell, unsigned int reference,
-                            std::vector<bool>& frontier_flag);
-
-  /**
-   * @brief isNewFrontierCell Evaluate if candidate cell is a valid candidate
-   * for a new frontier.
-   * @param idx Index of candidate cell
-   * @param frontier_flag Flag vector indicating which cells are already marked
-   * as frontiers
-   * @return true if the cell is frontier cell
-   */
-  bool isNewFrontierCell(unsigned int idx,
-                         const std::vector<bool>& frontier_flag);
-
-  /**
-   * @brief computes frontier cost
-   * @details cost function is defined by potential_scale and gain_scale
+   * @brief Represents a frontier
    *
-   * @param frontier frontier for which compute the cost
-   * @return cost of the frontier
    */
-  double frontierCost(const Frontier& frontier);
+  struct Frontier
+  {
+    std::uint32_t size;
+    double min_distance;
+    double cost;
+    geometry_msgs::msg::Point initial;
+    geometry_msgs::msg::Point centroid;
+    geometry_msgs::msg::Point middle;
+    std::vector<geometry_msgs::msg::Point> points;
+  };
 
-private:
-  nav2_costmap_2d::Costmap2D* costmap_;
-  unsigned char* map_;
-  unsigned int size_x_, size_y_;
-  double potential_scale_, gain_scale_;
-  double min_frontier_size_;
-};
+  /**
+   * @brief Thread-safe implementation of a frontier-search task for an input
+   * costmap.
+   */
+  class FrontierSearch
+  {
+  public:
+    FrontierSearch() : logger_(rclcpp::get_logger("frontier_search")) {} // Default constructor for the logger
+
+    /**
+     * @brief Constructor for search task
+     * @param costmap Reference to costmap data to search.
+     */
+    FrontierSearch(nav2_costmap_2d::Costmap2D* costmap, double potential_scale,
+      double gain_scale, double min_frontier_size,
+      rclcpp::Logger logger);
+
+    /**
+     * @brief Runs search implementation, outward from the start position
+     * @param position Initial position to search from
+     * @return List of frontiers, if any
+     */
+    std::vector<Frontier> searchFrom(geometry_msgs::msg::Point position);
+
+  protected:
+    /**
+     * @brief Starting from an initial cell, build a frontier from valid adjacent
+     * cells
+     * @param initial_cell Index of cell to start frontier building
+     * @param reference Reference index to calculate position from
+     * @param frontier_flag Flag vector indicating which cells are already marked
+     * as frontiers
+     * @return new frontier
+     */
+    Frontier buildNewFrontier(unsigned int initial_cell, unsigned int reference,
+      std::vector<bool>& frontier_flag);
+
+    /**
+     * @brief isNewFrontierCell Evaluate if candidate cell is a valid candidate
+     * for a new frontier.
+     * @param idx Index of candidate cell
+     * @param frontier_flag Flag vector indicating which cells are already marked
+     * as frontiers
+     * @return true if the cell is frontier cell
+     */
+    bool isNewFrontierCell(unsigned int idx,
+      const std::vector<bool>& frontier_flag);
+
+    /**
+     * @brief computes frontier cost
+     * @details cost function is defined by potential_scale and gain_scale
+     *
+     * @param frontier frontier for which compute the cost
+     * @return cost of the frontier
+     */
+    double frontierCost(const Frontier& frontier);
+
+  private:
+    nav2_costmap_2d::Costmap2D* costmap_;
+    unsigned char* map_;
+    unsigned int size_x_, size_y_;
+    double potential_scale_, gain_scale_;
+    double min_frontier_size_;
+    rclcpp::Logger logger_;
+  };
 }  // namespace frontier_exploration
 #endif

--- a/explore/src/explore.cpp
+++ b/explore/src/explore.cpp
@@ -85,7 +85,7 @@ namespace explore
 
         search_ = frontier_exploration::FrontierSearch(costmap_client_.getCostmap(),
             potential_scale_, gain_scale_,
-            min_frontier_size);
+            min_frontier_size, this->get_logger());
 
         if (visualize_) {
             marker_array_publisher_ =
@@ -106,12 +106,12 @@ namespace explore
             "explore/resume", 10,
             std::bind(&Explore::resumeCallback, this, std::placeholders::_1));
 
-        RCLCPP_INFO(logger_, "Waiting to connect to move_base nav2 server");
+        RCLCPP_INFO(this->get_logger(), "Waiting to connect to move_base nav2 server");
         move_base_client_->wait_for_action_server();
-        RCLCPP_INFO(logger_, "Connected to move_base nav2 server");
+        RCLCPP_INFO(this->get_logger(), "Connected to move_base nav2 server");
 
         if (return_to_init_) {
-            RCLCPP_INFO(logger_, "Getting initial pose of the robot");
+            RCLCPP_INFO(this->get_logger(), "Getting initial pose of the robot");
             geometry_msgs::msg::TransformStamped transformStamped;
             std::string map_frame = costmap_client_.getGlobalFrameID();
             try {
@@ -122,7 +122,7 @@ namespace explore
                 initial_pose_.orientation = transformStamped.transform.rotation;
             }
             catch (tf2::TransformException& ex) {
-                RCLCPP_ERROR(logger_, "Couldn't find transform from %s to %s: %s",
+                RCLCPP_ERROR(this->get_logger(), "Couldn't find transform from %s to %s: %s",
                     map_frame.c_str(), robot_base_frame_.c_str(), ex.what());
                 return_to_init_ = false;
             }
@@ -166,7 +166,7 @@ namespace explore
         green.b = 0;
         green.a = 1.0;
 
-        RCLCPP_DEBUG(logger_, "visualising %lu frontiers", frontiers.size());
+        RCLCPP_DEBUG(this->get_logger(), "visualising %lu frontiers", frontiers.size());
         visualization_msgs::msg::MarkerArray markers_msg;
         std::vector<visualization_msgs::msg::Marker>& markers = markers_msg.markers;
         visualization_msgs::msg::Marker m;
@@ -250,13 +250,13 @@ namespace explore
         auto pose = costmap_client_.getRobotPose();
         // get frontiers sorted according to cost
         auto frontiers = search_.searchFrom(pose.position);
-        RCLCPP_INFO(logger_, "found %lu frontiers", frontiers.size());
+        RCLCPP_INFO(this->get_logger(), "found %lu frontiers", frontiers.size());
         for (size_t i = 0; i < frontiers.size(); ++i) {
-            RCLCPP_DEBUG(logger_, "frontier %zd cost: %f", i, frontiers[i].cost);
+            RCLCPP_DEBUG(this->get_logger(), "frontier %zd cost: %f", i, frontiers[i].cost);
         }
 
         if (frontiers.empty()) {
-            RCLCPP_WARN(logger_, "No frontiers found, stopping.");
+            RCLCPP_WARN(this->get_logger(), "No frontiers found, stopping.");
             stop(true);
             return;
         }
@@ -273,7 +273,7 @@ namespace explore
                     return goalOnBlacklist(f.centroid);
                 });
         if (frontier == frontiers.end()) {
-            RCLCPP_WARN(logger_, "All frontiers traversed/tried out/blacklisted, stopping.");
+            RCLCPP_WARN(this->get_logger(), "All frontiers traversed/tried out/blacklisted, stopping.");
             stop(true);
             return;
         }
@@ -292,7 +292,7 @@ namespace explore
         if ((this->now() - last_progress_ >
             tf2::durationFromSec(progress_timeout_)) && !resuming_) {
             frontier_blacklist_.push_back(target_position);
-            RCLCPP_INFO(logger_, "Adding current goal (%f, %f) to blacklist, because no progress for a long time!", target_position.x, target_position.y);
+            RCLCPP_INFO(this->get_logger(), "Adding current goal (%f, %f) to blacklist, because no progress for a long time!", target_position.x, target_position.y);
             makePlan();
             return;
         }
@@ -308,7 +308,7 @@ namespace explore
         }
 
 
-        RCLCPP_INFO(logger_, "Sending goal (%f, %f) to move base nav2", target_position.x, target_position.y);
+        RCLCPP_INFO(this->get_logger(), "Sending goal (%f, %f) to move base nav2", target_position.x, target_position.y);
         // publish goal to goal_sent topic
         geometry_msgs::msg::Point goal_msg;
         goal_sent_publisher_->publish(target_position);
@@ -336,7 +336,7 @@ namespace explore
     }
 
     void Explore::returnToInitialPose() {
-        RCLCPP_INFO(logger_, "Returning to initial pose.");
+        RCLCPP_INFO(this->get_logger(), "Returning to initial pose.");
         auto goal = nav2_msgs::action::NavigateToPose::Goal();
         goal.pose.pose.position = initial_pose_.position;
         goal.pose.pose.orientation = initial_pose_.orientation;
@@ -368,24 +368,24 @@ namespace explore
         const geometry_msgs::msg::Point& frontier_goal) {
         switch (result.code) {
         case rclcpp_action::ResultCode::SUCCEEDED:
-            RCLCPP_INFO(logger_, "Goal (%f, %f) was successful", frontier_goal.x, frontier_goal.y);
+            RCLCPP_INFO(this->get_logger(), "Goal (%f, %f) was successful", frontier_goal.x, frontier_goal.y);
             // Publish the result on the goal_reached topic
             goal_reached_publisher_->publish(frontier_goal);
 
             break;
         case rclcpp_action::ResultCode::ABORTED:
-            RCLCPP_INFO(logger_, "Goal (%f, %f) was aborted by the navigation stack", frontier_goal.x, frontier_goal.y);
+            RCLCPP_INFO(this->get_logger(), "Goal (%f, %f) was aborted by the navigation stack", frontier_goal.x, frontier_goal.y);
             frontier_blacklist_.push_back(frontier_goal); //TODO: is it really necessary to add the aborted goal to the blacklist?
-            RCLCPP_INFO(logger_, "Adding current goal (%f, %f) to black list because it was aborted!", frontier_goal.x, frontier_goal.y);
+            RCLCPP_INFO(this->get_logger(), "Adding current goal (%f, %f) to black list because it was aborted!", frontier_goal.x, frontier_goal.y);
             // If it was aborted probably because we've found another frontier goal,
             // so just return and don't make plan again
             return;
         case rclcpp_action::ResultCode::CANCELED:
-            RCLCPP_INFO(logger_, "Goal (%f, %f) was canceled by the navigation stack", frontier_goal.x, frontier_goal.y);
+            RCLCPP_INFO(this->get_logger(), "Goal (%f, %f) was canceled by the navigation stack", frontier_goal.x, frontier_goal.y);
             // If goal canceled might be because exploration stopped from topic. Don't make new plan.
             return;
         default:
-            RCLCPP_WARN(logger_, "Unknown result code from move base nav2");
+            RCLCPP_WARN(this->get_logger(), "Unknown result code from move base nav2");
             break;
         }
         // find new goal immediately regardless of planning frequency.
@@ -402,11 +402,11 @@ namespace explore
     }
 
     void Explore::start() {
-        RCLCPP_INFO(logger_, "Exploration started.");
+        RCLCPP_INFO(this->get_logger(), "Exploration started.");
     }
 
     void Explore::stop(bool finished_exploring) {
-        RCLCPP_INFO(logger_, "Exploration stopped.");
+        RCLCPP_INFO(this->get_logger(), "Exploration stopped.");
         move_base_client_->async_cancel_all_goals();
         exploring_timer_->cancel();
 
@@ -415,7 +415,7 @@ namespace explore
 
         if (return_to_init_ && finished_exploring) {
             // We send a msg to /goal_reached to indicate that exploration is finished
-            RCLCPP_INFO(logger_, "Sending goal reached message to indicate exploration finished.");
+            RCLCPP_INFO(this->get_logger(), "Sending goal reached message to indicate exploration finished.");
             geometry_msgs::msg::Point goal_msg;
             goal_msg.x = 0.0;
             goal_msg.y = 0.0;
@@ -426,7 +426,7 @@ namespace explore
             returnToInitialPose();
             // We shut down the node
             // TODO : add a timer / wait for the initial pose to be reached
-            RCLCPP_INFO(logger_, "Shutting down the explore node.");
+            RCLCPP_INFO(this->get_logger(), "Shutting down the explore node.");
             rclcpp::shutdown();
         }
 
@@ -435,7 +435,7 @@ namespace explore
 
     void Explore::resume() {
         resuming_ = true;
-        RCLCPP_INFO(logger_, "Exploration resuming.");
+        RCLCPP_INFO(this->get_logger(), "Exploration resuming.");
         // Reactivate the timer
         exploring_timer_->reset();
         // Resume immediately

--- a/explore/src/explore.cpp
+++ b/explore/src/explore.cpp
@@ -405,19 +405,27 @@ namespace explore
         move_base_client_->async_cancel_all_goals();
         exploring_timer_->cancel();
 
-        // We send a msg to /goal_reached to indicate that exploration is finished
-        RCLCPP_INFO(logger_, "Sending goal reached message to indicate exploration finished.");
-        geometry_msgs::msg::Point goal_msg;
-        goal_msg.x = 0.0;
-        goal_msg.y = 0.0;
-        goal_msg.z = 0.0;
-        goal_reached_publisher_->publish(goal_msg);
 
 
 
         if (return_to_init_ && finished_exploring) {
+            // We send a msg to /goal_reached to indicate that exploration is finished
+            RCLCPP_INFO(logger_, "Sending goal reached message to indicate exploration finished.");
+            geometry_msgs::msg::Point goal_msg;
+            goal_msg.x = 0.0;
+            goal_msg.y = 0.0;
+            goal_msg.z = 0.0;
+            goal_reached_publisher_->publish(goal_msg);
+
+            // We return to the initial pose
             returnToInitialPose();
+            // We shut down the node
+            // TODO : add a timer / wait for the initial pose to be reached
+            RCLCPP_INFO(logger_, "Shutting down the explore node.");
+            rclcpp::shutdown();
         }
+
+
     }
 
     void Explore::resume() {

--- a/explore/src/explore.cpp
+++ b/explore/src/explore.cpp
@@ -41,392 +41,391 @@
 #include <thread>
 
 inline static bool same_point(const geometry_msgs::msg::Point& one,
-                              const geometry_msgs::msg::Point& two)
-{
-  double dx = one.x - two.x;
-  double dy = one.y - two.y;
-  double dist = sqrt(dx * dx + dy * dy);
-  return dist < 0.01;
+    const geometry_msgs::msg::Point& two) {
+    double dx = one.x - two.x;
+    double dy = one.y - two.y;
+    double dist = sqrt(dx * dx + dy * dy);
+    return dist < 0.01;
 }
 
 namespace explore
 {
-Explore::Explore()
-  : Node("explore_node")
-  , tf_buffer_(this->get_clock())
-  , tf_listener_(tf_buffer_)
-  , costmap_client_(*this, &tf_buffer_)
-  , prev_distance_(0)
-  , last_markers_count_(0)
-{
-  double timeout;
-  double min_frontier_size;
-  this->declare_parameter<float>("planner_frequency", 1.0);
-  this->declare_parameter<float>("progress_timeout", 30.0);
-  this->declare_parameter<bool>("visualize", false);
-  this->declare_parameter<float>("potential_scale", 1e-3);
-  this->declare_parameter<float>("orientation_scale", 0.0);
-  this->declare_parameter<float>("gain_scale", 1.0);
-  this->declare_parameter<float>("min_frontier_size", 0.5);
-  this->declare_parameter<bool>("return_to_init", false);
+    Explore::Explore()
+        : Node("explore_node")
+        , tf_buffer_(this->get_clock())
+        , tf_listener_(tf_buffer_)
+        , costmap_client_(*this, &tf_buffer_)
+        , prev_distance_(0)
+        , last_markers_count_(0) {
+        double timeout;
+        double min_frontier_size;
+        this->declare_parameter<float>("planner_frequency", 1.0);
+        this->declare_parameter<float>("progress_timeout", 30.0);
+        this->declare_parameter<bool>("visualize", false);
+        this->declare_parameter<float>("potential_scale", 1e-3);
+        this->declare_parameter<float>("orientation_scale", 0.0);
+        this->declare_parameter<float>("gain_scale", 1.0);
+        this->declare_parameter<float>("min_frontier_size", 0.5);
+        this->declare_parameter<bool>("return_to_init", false);
 
-  this->get_parameter("planner_frequency", planner_frequency_);
-  this->get_parameter("progress_timeout", timeout);
-  this->get_parameter("visualize", visualize_);
-  this->get_parameter("potential_scale", potential_scale_);
-  this->get_parameter("orientation_scale", orientation_scale_);
-  this->get_parameter("gain_scale", gain_scale_);
-  this->get_parameter("min_frontier_size", min_frontier_size);
-  this->get_parameter("return_to_init", return_to_init_);
-  this->get_parameter("robot_base_frame", robot_base_frame_);
+        this->get_parameter("planner_frequency", planner_frequency_);
+        this->get_parameter("progress_timeout", timeout);
+        this->get_parameter("visualize", visualize_);
+        this->get_parameter("potential_scale", potential_scale_);
+        this->get_parameter("orientation_scale", orientation_scale_);
+        this->get_parameter("gain_scale", gain_scale_);
+        this->get_parameter("min_frontier_size", min_frontier_size);
+        this->get_parameter("return_to_init", return_to_init_);
+        this->get_parameter("robot_base_frame", robot_base_frame_);
 
-  progress_timeout_ = timeout;
-  move_base_client_ =
-      rclcpp_action::create_client<nav2_msgs::action::NavigateToPose>(
-          this, ACTION_NAME);
+        progress_timeout_ = timeout;
+        move_base_client_ =
+            rclcpp_action::create_client<nav2_msgs::action::NavigateToPose>(
+                this, ACTION_NAME);
 
-  search_ = frontier_exploration::FrontierSearch(costmap_client_.getCostmap(),
-                                                 potential_scale_, gain_scale_,
-                                                 min_frontier_size);
+        search_ = frontier_exploration::FrontierSearch(costmap_client_.getCostmap(),
+            potential_scale_, gain_scale_,
+            min_frontier_size);
 
-  if (visualize_) {
-    marker_array_publisher_ =
-        this->create_publisher<visualization_msgs::msg::MarkerArray>("explore/"
-                                                                     "frontier"
-                                                                     "s",
-                                                                     10);
-  }
+        if (visualize_) {
+            marker_array_publisher_ =
+                this->create_publisher<visualization_msgs::msg::MarkerArray>("explore/"
+                    "frontier"
+                    "s",
+                    10);
+        }
 
-  // Subscription to resume or stop exploration
-  resume_subscription_ = this->create_subscription<std_msgs::msg::Bool>(
-      "explore/resume", 10,
-      std::bind(&Explore::resumeCallback, this, std::placeholders::_1));
+        // Add a publisher to the goal_sent topic 
+        goal_sent_publisher_ = this->create_publisher<geometry_msgs::msg::Point>("/goal_sent", 10);
 
-  RCLCPP_INFO(logger_, "Waiting to connect to move_base nav2 server");
-  move_base_client_->wait_for_action_server();
-  RCLCPP_INFO(logger_, "Connected to move_base nav2 server");
 
-  if (return_to_init_) {
-    RCLCPP_INFO(logger_, "Getting initial pose of the robot");
-    geometry_msgs::msg::TransformStamped transformStamped;
-    std::string map_frame = costmap_client_.getGlobalFrameID();
-    try {
-      transformStamped = tf_buffer_.lookupTransform(
-          map_frame, robot_base_frame_, tf2::TimePointZero);
-      initial_pose_.position.x = transformStamped.transform.translation.x;
-      initial_pose_.position.y = transformStamped.transform.translation.y;
-      initial_pose_.orientation = transformStamped.transform.rotation;
-    } catch (tf2::TransformException& ex) {
-      RCLCPP_ERROR(logger_, "Couldn't find transform from %s to %s: %s",
-                   map_frame.c_str(), robot_base_frame_.c_str(), ex.what());
-      return_to_init_ = false;
+        // Subscription to resume or stop exploration
+        resume_subscription_ = this->create_subscription<std_msgs::msg::Bool>(
+            "explore/resume", 10,
+            std::bind(&Explore::resumeCallback, this, std::placeholders::_1));
+
+        RCLCPP_INFO(logger_, "Waiting to connect to move_base nav2 server");
+        move_base_client_->wait_for_action_server();
+        RCLCPP_INFO(logger_, "Connected to move_base nav2 server");
+
+        if (return_to_init_) {
+            RCLCPP_INFO(logger_, "Getting initial pose of the robot");
+            geometry_msgs::msg::TransformStamped transformStamped;
+            std::string map_frame = costmap_client_.getGlobalFrameID();
+            try {
+                transformStamped = tf_buffer_.lookupTransform(
+                    map_frame, robot_base_frame_, tf2::TimePointZero);
+                initial_pose_.position.x = transformStamped.transform.translation.x;
+                initial_pose_.position.y = transformStamped.transform.translation.y;
+                initial_pose_.orientation = transformStamped.transform.rotation;
+            }
+            catch (tf2::TransformException& ex) {
+                RCLCPP_ERROR(logger_, "Couldn't find transform from %s to %s: %s",
+                    map_frame.c_str(), robot_base_frame_.c_str(), ex.what());
+                return_to_init_ = false;
+            }
+        }
+
+        exploring_timer_ = this->create_wall_timer(
+            std::chrono::milliseconds((uint16_t)(1000.0 / planner_frequency_)),
+            [this]() { makePlan(); });
+        // Start exploration right away
+        makePlan();
     }
-  }
 
-  exploring_timer_ = this->create_wall_timer(
-      std::chrono::milliseconds((uint16_t)(1000.0 / planner_frequency_)),
-      [this]() { makePlan(); });
-  // Start exploration right away
-  makePlan();
-}
-
-Explore::~Explore()
-{
-  stop();
-}
-
-void Explore::resumeCallback(const std_msgs::msg::Bool::SharedPtr msg)
-{
-  if (msg->data) {
-    resume();
-  } else {
-    stop();
-  }
-}
-
-void Explore::visualizeFrontiers(
-    const std::vector<frontier_exploration::Frontier>& frontiers)
-{
-  std_msgs::msg::ColorRGBA blue;
-  blue.r = 0;
-  blue.g = 0;
-  blue.b = 1.0;
-  blue.a = 1.0;
-  std_msgs::msg::ColorRGBA red;
-  red.r = 1.0;
-  red.g = 0;
-  red.b = 0;
-  red.a = 1.0;
-  std_msgs::msg::ColorRGBA green;
-  green.r = 0;
-  green.g = 1.0;
-  green.b = 0;
-  green.a = 1.0;
-
-  RCLCPP_DEBUG(logger_, "visualising %lu frontiers", frontiers.size());
-  visualization_msgs::msg::MarkerArray markers_msg;
-  std::vector<visualization_msgs::msg::Marker>& markers = markers_msg.markers;
-  visualization_msgs::msg::Marker m;
-
-  m.header.frame_id = costmap_client_.getGlobalFrameID();
-  m.header.stamp = this->now();
-  m.ns = "frontiers";
-  m.scale.x = 1.0;
-  m.scale.y = 1.0;
-  m.scale.z = 1.0;
-  m.color.r = 0;
-  m.color.g = 0;
-  m.color.b = 255;
-  m.color.a = 255;
-  // lives forever
-#ifdef ELOQUENT
-  m.lifetime = rclcpp::Duration(0);  // deprecated in galactic warning
-#elif DASHING
-  m.lifetime = rclcpp::Duration(0);  // deprecated in galactic warning
-#else
-  m.lifetime = rclcpp::Duration::from_seconds(0);  // foxy onwards
-#endif
-  // m.lifetime = rclcpp::Duration::from_nanoseconds(0); // suggested in
-  // galactic
-  m.frame_locked = true;
-
-  // weighted frontiers are always sorted
-  double min_cost = frontiers.empty() ? 0. : frontiers.front().cost;
-
-  m.action = visualization_msgs::msg::Marker::ADD;
-  size_t id = 0;
-  for (auto& frontier : frontiers) {
-    m.type = visualization_msgs::msg::Marker::POINTS;
-    m.id = int(id);
-    // m.pose.position = {}; // compile warning
-    m.scale.x = 0.1;
-    m.scale.y = 0.1;
-    m.scale.z = 0.1;
-    m.points = frontier.points;
-    if (goalOnBlacklist(frontier.centroid)) {
-      m.color = red;
-    } else {
-      m.color = blue;
+    Explore::~Explore() {
+        stop();
     }
-    markers.push_back(m);
-    ++id;
-    m.type = visualization_msgs::msg::Marker::SPHERE;
-    m.id = int(id);
-    m.pose.position = frontier.initial;
-    // scale frontier according to its cost (costier frontiers will be smaller)
-    double scale = std::min(std::abs(min_cost * 0.4 / frontier.cost), 0.5);
-    m.scale.x = scale;
-    m.scale.y = scale;
-    m.scale.z = scale;
-    m.points = {};
-    m.color = green;
-    markers.push_back(m);
-    ++id;
-  }
-  size_t current_markers_count = markers.size();
 
-  // delete previous markers, which are now unused
-  m.action = visualization_msgs::msg::Marker::DELETE;
-  for (; id < last_markers_count_; ++id) {
-    m.id = int(id);
-    markers.push_back(m);
-  }
+    void Explore::resumeCallback(const std_msgs::msg::Bool::SharedPtr msg) {
+        if (msg->data) {
+            resume();
+        }
+        else {
+            stop();
+        }
+    }
 
-  last_markers_count_ = current_markers_count;
-  marker_array_publisher_->publish(markers_msg);
-}
+    void Explore::visualizeFrontiers(
+        const std::vector<frontier_exploration::Frontier>& frontiers) {
+        std_msgs::msg::ColorRGBA blue;
+        blue.r = 0;
+        blue.g = 0;
+        blue.b = 1.0;
+        blue.a = 1.0;
+        std_msgs::msg::ColorRGBA red;
+        red.r = 1.0;
+        red.g = 0;
+        red.b = 0;
+        red.a = 1.0;
+        std_msgs::msg::ColorRGBA green;
+        green.r = 0;
+        green.g = 1.0;
+        green.b = 0;
+        green.a = 1.0;
 
-void Explore::makePlan()
-{
-  // find frontiers
-  auto pose = costmap_client_.getRobotPose();
-  // get frontiers sorted according to cost
-  auto frontiers = search_.searchFrom(pose.position);
-  RCLCPP_DEBUG(logger_, "found %lu frontiers", frontiers.size());
-  for (size_t i = 0; i < frontiers.size(); ++i) {
-    RCLCPP_DEBUG(logger_, "frontier %zd cost: %f", i, frontiers[i].cost);
-  }
+        RCLCPP_DEBUG(logger_, "visualising %lu frontiers", frontiers.size());
+        visualization_msgs::msg::MarkerArray markers_msg;
+        std::vector<visualization_msgs::msg::Marker>& markers = markers_msg.markers;
+        visualization_msgs::msg::Marker m;
 
-  if (frontiers.empty()) {
-    RCLCPP_WARN(logger_, "No frontiers found, stopping.");
-    stop(true);
-    return;
-  }
+        m.header.frame_id = costmap_client_.getGlobalFrameID();
+        m.header.stamp = this->now();
+        m.ns = "frontiers";
+        m.scale.x = 1.0;
+        m.scale.y = 1.0;
+        m.scale.z = 1.0;
+        m.color.r = 0;
+        m.color.g = 0;
+        m.color.b = 255;
+        m.color.a = 255;
+        // lives forever
+        #ifdef ELOQUENT
+        m.lifetime = rclcpp::Duration(0);  // deprecated in galactic warning
+        #elif DASHING
+        m.lifetime = rclcpp::Duration(0);  // deprecated in galactic warning
+        #else
+        m.lifetime = rclcpp::Duration::from_seconds(0);  // foxy onwards
+        #endif
+        // m.lifetime = rclcpp::Duration::from_nanoseconds(0); // suggested in
+        // galactic
+        m.frame_locked = true;
 
-  // publish frontiers as visualization markers
-  if (visualize_) {
-    visualizeFrontiers(frontiers);
-  }
+        // weighted frontiers are always sorted
+        double min_cost = frontiers.empty() ? 0. : frontiers.front().cost;
 
-  // find non blacklisted frontier
-  auto frontier =
-      std::find_if_not(frontiers.begin(), frontiers.end(),
-                       [this](const frontier_exploration::Frontier& f) {
-                         return goalOnBlacklist(f.centroid);
-                       });
-  if (frontier == frontiers.end()) {
-    RCLCPP_WARN(logger_, "All frontiers traversed/tried out, stopping.");
-    stop(true);
-    return;
-  }
-  geometry_msgs::msg::Point target_position = frontier->centroid;
+        m.action = visualization_msgs::msg::Marker::ADD;
+        size_t id = 0;
+        for (auto& frontier : frontiers) {
+            m.type = visualization_msgs::msg::Marker::POINTS;
+            m.id = int(id);
+            // m.pose.position = {}; // compile warning
+            m.scale.x = 0.1;
+            m.scale.y = 0.1;
+            m.scale.z = 0.1;
+            m.points = frontier.points;
+            if (goalOnBlacklist(frontier.centroid)) {
+                m.color = red;
+            }
+            else {
+                m.color = blue;
+            }
+            markers.push_back(m);
+            ++id;
+            m.type = visualization_msgs::msg::Marker::SPHERE;
+            m.id = int(id);
+            m.pose.position = frontier.initial;
+            // scale frontier according to its cost (costier frontiers will be smaller)
+            double scale = std::min(std::abs(min_cost * 0.4 / frontier.cost), 0.5);
+            m.scale.x = scale;
+            m.scale.y = scale;
+            m.scale.z = scale;
+            m.points = {};
+            m.color = green;
+            markers.push_back(m);
+            ++id;
+        }
+        size_t current_markers_count = markers.size();
 
-  // time out if we are not making any progress
-  bool same_goal = same_point(prev_goal_, target_position);
+        // delete previous markers, which are now unused
+        m.action = visualization_msgs::msg::Marker::DELETE;
+        for (; id < last_markers_count_; ++id) {
+            m.id = int(id);
+            markers.push_back(m);
+        }
 
-  prev_goal_ = target_position;
-  if (!same_goal || prev_distance_ > frontier->min_distance) {
-    // we have different goal or we made some progress
-    last_progress_ = this->now();
-    prev_distance_ = frontier->min_distance;
-  }
-  // black list if we've made no progress for a long time
-  if ((this->now() - last_progress_ >
-      tf2::durationFromSec(progress_timeout_)) && !resuming_) {
-    frontier_blacklist_.push_back(target_position);
-    RCLCPP_DEBUG(logger_, "Adding current goal to black list");
-    makePlan();
-    return;
-  }
+        last_markers_count_ = current_markers_count;
+        marker_array_publisher_->publish(markers_msg);
+    }
 
-  // ensure only first call of makePlan was set resuming to true
-  if (resuming_) {
-    resuming_ = false;
-  }
+    void Explore::makePlan() {
+        // find frontiers
+        auto pose = costmap_client_.getRobotPose();
+        // get frontiers sorted according to cost
+        auto frontiers = search_.searchFrom(pose.position);
+        RCLCPP_DEBUG(logger_, "found %lu frontiers", frontiers.size());
+        for (size_t i = 0; i < frontiers.size(); ++i) {
+            RCLCPP_DEBUG(logger_, "frontier %zd cost: %f", i, frontiers[i].cost);
+        }
 
-  // we don't need to do anything if we still pursuing the same goal
-  if (same_goal) {
-    return;
-  }
+        if (frontiers.empty()) {
+            RCLCPP_WARN(logger_, "No frontiers found, stopping.");
+            stop(true);
+            return;
+        }
 
-  RCLCPP_DEBUG(logger_, "Sending goal to move base nav2");
+        // publish frontiers as visualization markers
+        if (visualize_) {
+            visualizeFrontiers(frontiers);
+        }
 
-  // send goal to move_base if we have something new to pursue
-  auto goal = nav2_msgs::action::NavigateToPose::Goal();
-  goal.pose.pose.position = target_position;
-  goal.pose.pose.orientation.w = 1.;
-  goal.pose.header.frame_id = costmap_client_.getGlobalFrameID();
-  goal.pose.header.stamp = this->now();
+        // find non blacklisted frontier
+        auto frontier =
+            std::find_if_not(frontiers.begin(), frontiers.end(),
+                [this](const frontier_exploration::Frontier& f) {
+                    return goalOnBlacklist(f.centroid);
+                });
+        if (frontier == frontiers.end()) {
+            RCLCPP_WARN(logger_, "All frontiers traversed/tried out, stopping.");
+            stop(true);
+            return;
+        }
+        geometry_msgs::msg::Point target_position = frontier->centroid;
 
-  auto send_goal_options =
-      rclcpp_action::Client<nav2_msgs::action::NavigateToPose>::SendGoalOptions();
-  // send_goal_options.goal_response_callback =
-  // std::bind(&Explore::goal_response_callback, this, _1);
-  // send_goal_options.feedback_callback =
-  //   std::bind(&Explore::feedback_callback, this, _1, _2);
-  send_goal_options.result_callback =
-      [this,
-       target_position](const NavigationGoalHandle::WrappedResult& result) {
-        reachedGoal(result, target_position);
-      };
-  move_base_client_->async_send_goal(goal, send_goal_options);
-}
+        // time out if we are not making any progress
+        bool same_goal = same_point(prev_goal_, target_position);
 
-void Explore::returnToInitialPose()
-{
-  RCLCPP_INFO(logger_, "Returning to initial pose.");
-  auto goal = nav2_msgs::action::NavigateToPose::Goal();
-  goal.pose.pose.position = initial_pose_.position;
-  goal.pose.pose.orientation = initial_pose_.orientation;
-  goal.pose.header.frame_id = costmap_client_.getGlobalFrameID();
-  goal.pose.header.stamp = this->now();
+        prev_goal_ = target_position;
+        if (!same_goal || prev_distance_ > frontier->min_distance) {
+            // we have different goal or we made some progress
+            last_progress_ = this->now();
+            prev_distance_ = frontier->min_distance;
+        }
+        // black list if we've made no progress for a long time
+        if ((this->now() - last_progress_ >
+            tf2::durationFromSec(progress_timeout_)) && !resuming_) {
+            frontier_blacklist_.push_back(target_position);
+            RCLCPP_DEBUG(logger_, "Adding current goal to black list");
+            makePlan();
+            return;
+        }
 
-  auto send_goal_options =
-      rclcpp_action::Client<nav2_msgs::action::NavigateToPose>::SendGoalOptions();
-  move_base_client_->async_send_goal(goal, send_goal_options);
-}
+        // ensure only first call of makePlan was set resuming to true
+        if (resuming_) {
+            resuming_ = false;
+        }
 
-bool Explore::goalOnBlacklist(const geometry_msgs::msg::Point& goal)
-{
-  constexpr static size_t tolerace = 5;
-  nav2_costmap_2d::Costmap2D* costmap2d = costmap_client_.getCostmap();
+        // we don't need to do anything if we still pursuing the same goal
+        if (same_goal) {
+            return;
+        }
 
-  // check if a goal is on the blacklist for goals that we're pursuing
-  for (auto& frontier_goal : frontier_blacklist_) {
-    double x_diff = fabs(goal.x - frontier_goal.x);
-    double y_diff = fabs(goal.y - frontier_goal.y);
 
-    if (x_diff < tolerace * costmap2d->getResolution() &&
-        y_diff < tolerace * costmap2d->getResolution())
-      return true;
-  }
-  return false;
-}
+        RCLCPP_DEBUG(logger_, "Sending goal to move base nav2");
+        // publish goal to goal_sent topic
+        geometry_msgs::msg::Point goal_msg;
+        goal_sent_publisher_->publish(target_position);
 
-void Explore::reachedGoal(const NavigationGoalHandle::WrappedResult& result,
-                          const geometry_msgs::msg::Point& frontier_goal)
-{
-  switch (result.code) {
-    case rclcpp_action::ResultCode::SUCCEEDED:
-      RCLCPP_DEBUG(logger_, "Goal was successful");
-      break;
-    case rclcpp_action::ResultCode::ABORTED:
-      RCLCPP_DEBUG(logger_, "Goal was aborted");
-      frontier_blacklist_.push_back(frontier_goal);
-      RCLCPP_DEBUG(logger_, "Adding current goal to black list");
-      // If it was aborted probably because we've found another frontier goal,
-      // so just return and don't make plan again
-      return;
-    case rclcpp_action::ResultCode::CANCELED:
-      RCLCPP_DEBUG(logger_, "Goal was canceled");
-      // If goal canceled might be because exploration stopped from topic. Don't make new plan.
-      return;
-    default:
-      RCLCPP_WARN(logger_, "Unknown result code from move base nav2");
-      break;
-  }
-  // find new goal immediately regardless of planning frequency.
-  // execute via timer to prevent dead lock in move_base_client (this is
-  // callback for sendGoal, which is called in makePlan). the timer must live
-  // until callback is executed.
-  // oneshot_ = relative_nh_.createTimer(
-  //     ros::Duration(0, 0), [this](const ros::TimerEvent&) { makePlan(); },
-  //     true);
 
-  // Because of the 1-thread-executor nature of ros2 I think timer is not
-  // needed.
-  makePlan();
-}
+        // send goal to move_base if we have something new to pursue
+        auto goal = nav2_msgs::action::NavigateToPose::Goal();
+        goal.pose.pose.position = target_position;
+        goal.pose.pose.orientation.w = 1.;
+        goal.pose.header.frame_id = costmap_client_.getGlobalFrameID();
+        goal.pose.header.stamp = this->now();
 
-void Explore::start()
-{
-  RCLCPP_INFO(logger_, "Exploration started.");
-}
+        auto send_goal_options =
+            rclcpp_action::Client<nav2_msgs::action::NavigateToPose>::SendGoalOptions();
+        // send_goal_options.goal_response_callback =
+        // std::bind(&Explore::goal_response_callback, this, _1);
+        // send_goal_options.feedback_callback =
+        //   std::bind(&Explore::feedback_callback, this, _1, _2);
+        send_goal_options.result_callback =
+            [this,
+            target_position](const NavigationGoalHandle::WrappedResult& result) {
+            reachedGoal(result, target_position);
+            };
+        move_base_client_->async_send_goal(goal, send_goal_options);
+    }
 
-void Explore::stop(bool finished_exploring)
-{
-  RCLCPP_INFO(logger_, "Exploration stopped.");
-  move_base_client_->async_cancel_all_goals();
-  exploring_timer_->cancel();
+    void Explore::returnToInitialPose() {
+        RCLCPP_INFO(logger_, "Returning to initial pose.");
+        auto goal = nav2_msgs::action::NavigateToPose::Goal();
+        goal.pose.pose.position = initial_pose_.position;
+        goal.pose.pose.orientation = initial_pose_.orientation;
+        goal.pose.header.frame_id = costmap_client_.getGlobalFrameID();
+        goal.pose.header.stamp = this->now();
 
-  if (return_to_init_ && finished_exploring) {
-    returnToInitialPose();
-  }
-}
+        auto send_goal_options =
+            rclcpp_action::Client<nav2_msgs::action::NavigateToPose>::SendGoalOptions();
+        move_base_client_->async_send_goal(goal, send_goal_options);
+    }
 
-void Explore::resume()
-{
-  resuming_ = true;
-  RCLCPP_INFO(logger_, "Exploration resuming.");
-  // Reactivate the timer
-  exploring_timer_->reset();
-  // Resume immediately
-  makePlan();
-}
+    bool Explore::goalOnBlacklist(const geometry_msgs::msg::Point& goal) {
+        constexpr static size_t tolerace = 5;
+        nav2_costmap_2d::Costmap2D* costmap2d = costmap_client_.getCostmap();
+
+        // check if a goal is on the blacklist for goals that we're pursuing
+        for (auto& frontier_goal : frontier_blacklist_) {
+            double x_diff = fabs(goal.x - frontier_goal.x);
+            double y_diff = fabs(goal.y - frontier_goal.y);
+
+            if (x_diff < tolerace * costmap2d->getResolution() &&
+                y_diff < tolerace * costmap2d->getResolution())
+                return true;
+        }
+        return false;
+    }
+
+    void Explore::reachedGoal(const NavigationGoalHandle::WrappedResult& result,
+        const geometry_msgs::msg::Point& frontier_goal) {
+        switch (result.code) {
+        case rclcpp_action::ResultCode::SUCCEEDED:
+            RCLCPP_DEBUG(logger_, "Goal was successful");
+            break;
+        case rclcpp_action::ResultCode::ABORTED:
+            RCLCPP_DEBUG(logger_, "Goal was aborted");
+            frontier_blacklist_.push_back(frontier_goal);
+            RCLCPP_DEBUG(logger_, "Adding current goal to black list");
+            // If it was aborted probably because we've found another frontier goal,
+            // so just return and don't make plan again
+            return;
+        case rclcpp_action::ResultCode::CANCELED:
+            RCLCPP_DEBUG(logger_, "Goal was canceled");
+            // If goal canceled might be because exploration stopped from topic. Don't make new plan.
+            return;
+        default:
+            RCLCPP_WARN(logger_, "Unknown result code from move base nav2");
+            break;
+        }
+        // find new goal immediately regardless of planning frequency.
+        // execute via timer to prevent dead lock in move_base_client (this is
+        // callback for sendGoal, which is called in makePlan). the timer must live
+        // until callback is executed.
+        // oneshot_ = relative_nh_.createTimer(
+        //     ros::Duration(0, 0), [this](const ros::TimerEvent&) { makePlan(); },
+        //     true);
+
+        // Because of the 1-thread-executor nature of ros2 I think timer is not
+        // needed.
+        makePlan();
+    }
+
+    void Explore::start() {
+        RCLCPP_INFO(logger_, "Exploration started.");
+    }
+
+    void Explore::stop(bool finished_exploring) {
+        RCLCPP_INFO(logger_, "Exploration stopped.");
+        move_base_client_->async_cancel_all_goals();
+        exploring_timer_->cancel();
+
+        if (return_to_init_ && finished_exploring) {
+            returnToInitialPose();
+        }
+    }
+
+    void Explore::resume() {
+        resuming_ = true;
+        RCLCPP_INFO(logger_, "Exploration resuming.");
+        // Reactivate the timer
+        exploring_timer_->reset();
+        // Resume immediately
+        makePlan();
+    }
 
 }  // namespace explore
 
-int main(int argc, char** argv)
-{
-  rclcpp::init(argc, argv);
-  // ROS1 code
-  /*
-  if (ros::console::set_logger_level(ROSCONSOLE_DEFAULT_NAME,
-                                     ros::console::levels::Debug)) {
-    ros::console::notifyLoggerLevelsChanged();
-  } */
-  rclcpp::spin(
-      std::make_shared<explore::Explore>());  // std::move(std::make_unique)?
-  rclcpp::shutdown();
-  return 0;
+int main(int argc, char** argv) {
+    rclcpp::init(argc, argv);
+    // ROS1 code
+    /*
+    if (ros::console::set_logger_level(ROSCONSOLE_DEFAULT_NAME,
+                                       ros::console::levels::Debug)) {
+      ros::console::notifyLoggerLevelsChanged();
+    } */
+    rclcpp::spin(
+        std::make_shared<explore::Explore>());  // std::move(std::make_unique)?
+    rclcpp::shutdown();
+    return 0;
 }

--- a/explore/src/frontier_search.cpp
+++ b/explore/src/frontier_search.cpp
@@ -106,7 +106,7 @@ Frontier FrontierSearch::buildNewFrontier(unsigned int initial_cell,
   Frontier output;
   output.centroid.x = 0;
   output.centroid.y = 0;
-  output.size = 1;
+  output.size = 0;
   output.min_distance = std::numeric_limits<double>::infinity();
 
   // record initial contact point for frontier

--- a/explore/src/frontier_search.cpp
+++ b/explore/src/frontier_search.cpp
@@ -14,11 +14,12 @@ using nav2_costmap_2d::NO_INFORMATION;
 
 FrontierSearch::FrontierSearch(nav2_costmap_2d::Costmap2D* costmap,
                                double potential_scale, double gain_scale,
-                               double min_frontier_size)
+                               double min_frontier_size, rclcpp::Logger logger)
   : costmap_(costmap)
   , potential_scale_(potential_scale)
   , gain_scale_(gain_scale)
   , min_frontier_size_(min_frontier_size)
+  , logger_(logger)
 {
 }
 
@@ -30,9 +31,7 @@ FrontierSearch::searchFrom(geometry_msgs::msg::Point position)
   // Sanity check that robot is inside costmap bounds before searching
   unsigned int mx, my;
   if (!costmap_->worldToMap(position.x, position.y, mx, my)) {
-    RCLCPP_ERROR(rclcpp::get_logger("FrontierSearch"), "Robot out of costmap "
-                                                       "bounds, cannot search "
-                                                       "for frontiers");
+    RCLCPP_ERROR(logger_, "FrontierSearch: Robot out of costmap bounds, cannot search for frontiers");
     return frontier_list;
   }
 
@@ -57,9 +56,7 @@ FrontierSearch::searchFrom(geometry_msgs::msg::Point position)
     bfs.push(clear);
   } else {
     bfs.push(pos);
-    RCLCPP_WARN(rclcpp::get_logger("FrontierSearch"), "Could not find nearby "
-                                                      "clear cell to start "
-                                                      "search");
+    RCLCPP_WARN(logger_, "FrontierSearch: Could not find nearby clear cell to start search");
   }
   visited_flag[bfs.front()] = true;
 

--- a/map_merge/src/map_merge.cpp
+++ b/map_merge/src/map_merge.cpp
@@ -41,403 +41,393 @@
 #include <map_merge/map_merge.h>
 #include <map_merge/ros1_names.hpp>
 #include <rcpputils/asserts.hpp>
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
 
 namespace map_merge
 {
-MapMerge::MapMerge() : Node("map_merge", rclcpp::NodeOptions()
-                                       .allow_undeclared_parameters(true)
-                                       .automatically_declare_parameters_from_overrides(true)),
-subscriptions_size_(0)
-{
-  std::string frame_id;
-  std::string merged_map_topic;
+  MapMerge::MapMerge() : Node("map_merge", rclcpp::NodeOptions()
+    .allow_undeclared_parameters(true)
+    .automatically_declare_parameters_from_overrides(true)),
+    subscriptions_size_(0) {
+    std::string frame_id;
+    std::string merged_map_topic;
 
-  if (!this->has_parameter("merging_rate")) this->declare_parameter<double>("merging_rate", 4.0);
-  if (!this->has_parameter("discovery_rate")) this->declare_parameter<double>("discovery_rate", 0.05);
-  if (!this->has_parameter("estimation_rate")) this->declare_parameter<double>("estimation_rate", 0.5);
-  if (!this->has_parameter("known_init_poses")) this->declare_parameter<bool>("known_init_poses", true);
-  if (!this->has_parameter("estimation_confidence")) this->declare_parameter<double>("estimation_confidence", 1.0);
-  if (!this->has_parameter("robot_map_topic")) this->declare_parameter<std::string>("robot_map_topic", "map");
-  if (!this->has_parameter("robot_map_updates_topic")) this->declare_parameter<std::string>("robot_map_updates_topic", "map_updates");
-  if (!this->has_parameter("robot_namespace")) this->declare_parameter<std::string>("robot_namespace", "");
-  if (!this->has_parameter("merged_map_topic")) this->declare_parameter<std::string>("merged_map_topic", "map");
-  if (!this->has_parameter("world_frame")) this->declare_parameter<std::string>("world_frame", "world");
-  
-  this->get_parameter("merging_rate", merging_rate_);
-  this->get_parameter("discovery_rate", discovery_rate_);
-  this->get_parameter("estimation_rate", estimation_rate_);
-  this->get_parameter("known_init_poses", have_initial_poses_);
-  this->get_parameter("estimation_confidence", confidence_threshold_);
-  this->get_parameter("robot_map_topic", robot_map_topic_);
-  this->get_parameter("robot_map_updates_topic", robot_map_updates_topic_);
-  this->get_parameter("robot_namespace", robot_namespace_);
-  this->get_parameter("merged_map_topic", merged_map_topic);
-  this->get_parameter("world_frame", world_frame_);
+    if (!this->has_parameter("merging_rate")) this->declare_parameter<double>("merging_rate", 4.0);
+    if (!this->has_parameter("discovery_rate")) this->declare_parameter<double>("discovery_rate", 0.05);
+    if (!this->has_parameter("estimation_rate")) this->declare_parameter<double>("estimation_rate", 0.5);
+    if (!this->has_parameter("known_init_poses")) this->declare_parameter<bool>("known_init_poses", true);
+    if (!this->has_parameter("estimation_confidence")) this->declare_parameter<double>("estimation_confidence", 1.0);
+    if (!this->has_parameter("robot_map_topic")) this->declare_parameter<std::string>("robot_map_topic", "map");
+    if (!this->has_parameter("robot_map_updates_topic")) this->declare_parameter<std::string>("robot_map_updates_topic", "map_updates");
+    if (!this->has_parameter("robot_namespace")) this->declare_parameter<std::string>("robot_namespace", "");
+    if (!this->has_parameter("merged_map_topic")) this->declare_parameter<std::string>("merged_map_topic", "map");
+    if (!this->has_parameter("world_frame")) this->declare_parameter<std::string>("world_frame", "world");
+
+    this->get_parameter("merging_rate", merging_rate_);
+    this->get_parameter("discovery_rate", discovery_rate_);
+    this->get_parameter("estimation_rate", estimation_rate_);
+    this->get_parameter("known_init_poses", have_initial_poses_);
+    this->get_parameter("estimation_confidence", confidence_threshold_);
+    this->get_parameter("robot_map_topic", robot_map_topic_);
+    this->get_parameter("robot_map_updates_topic", robot_map_updates_topic_);
+    this->get_parameter("robot_namespace", robot_namespace_);
+    this->get_parameter("merged_map_topic", merged_map_topic);
+    this->get_parameter("world_frame", world_frame_);
 
 
-  /* publishing */
-  // Create a publisher using the QoS settings to emulate a ROS1 latched topic
-  merged_map_publisher_ =
-      this->create_publisher<nav_msgs::msg::OccupancyGrid>(merged_map_topic, 
-      rclcpp::QoS(rclcpp::KeepLast(1)).transient_local().reliable());
+    /* publishing */
+    // Create a publisher using the QoS settings to emulate a ROS1 latched topic
+    merged_map_publisher_ =
+      this->create_publisher<nav_msgs::msg::OccupancyGrid>(merged_map_topic,
+        rclcpp::QoS(rclcpp::KeepLast(1)).transient_local().reliable());
 
-  // Timers
-  map_merging_timer_ = this->create_wall_timer(
-    std::chrono::milliseconds((uint16_t)(1000.0 / merging_rate_)),
-    [this]() { mapMerging(); });
-  // execute right away to simulate the ros1 first while loop on a thread
-  map_merging_timer_->execute_callback();
-
-  topic_subscribing_timer_ = this->create_wall_timer(
-    std::chrono::milliseconds((uint16_t)(1000.0 / discovery_rate_)),
-    [this]() { topicSubscribing(); });
-
-  // For topicSubscribing() we need to spin briefly for the discovery to happen
-  rclcpp::Rate r(100);
-  int i = 0;
-  while (rclcpp::ok() && i < 100) {
-    rclcpp::spin_some(this->get_node_base_interface());
-    r.sleep();
-    i++;
-  }
-  topic_subscribing_timer_->execute_callback(); 
-
-  if (!have_initial_poses_){
-    pose_estimation_timer_ = this->create_wall_timer(
-      std::chrono::milliseconds((uint16_t)(1000.0 / estimation_rate_)),
-      [this]() { poseEstimation(); });
+    // Timers
+    map_merging_timer_ = this->create_wall_timer(
+      std::chrono::milliseconds((uint16_t)(1000.0 / merging_rate_)),
+      [this]() { mapMerging(); });
     // execute right away to simulate the ros1 first while loop on a thread
-    pose_estimation_timer_->execute_callback(); 
+    map_merging_timer_->execute_callback();
+
+    topic_subscribing_timer_ = this->create_wall_timer(
+      std::chrono::milliseconds((uint16_t)(1000.0 / discovery_rate_)),
+      [this]() { topicSubscribing(); });
+
+    // For topicSubscribing() we need to spin briefly for the discovery to happen
+    rclcpp::Rate r(100);
+    int i = 0;
+    while (rclcpp::ok() && i < 100) {
+      rclcpp::spin_some(this->get_node_base_interface());
+      r.sleep();
+      i++;
+    }
+    topic_subscribing_timer_->execute_callback();
+
+    if (!have_initial_poses_) {
+      pose_estimation_timer_ = this->create_wall_timer(
+        std::chrono::milliseconds((uint16_t)(1000.0 / estimation_rate_)),
+        [this]() { poseEstimation(); });
+      // execute right away to simulate the ros1 first while loop on a thread
+      pose_estimation_timer_->execute_callback();
+    }
   }
-}
 
-/*
- * Subcribe to pose and map topics
- */
-void MapMerge::topicSubscribing()
-{
-  RCLCPP_DEBUG(logger_, "Robot discovery started.");
-  RCLCPP_INFO_ONCE(logger_, "Robot discovery started.");
+  /*
+   * Subcribe to pose and map topics
+   */
+  void MapMerge::topicSubscribing() {
+    RCLCPP_DEBUG(logger_, "Robot discovery started.");
+    RCLCPP_INFO_ONCE(logger_, "Robot discovery started.");
 
-  // ros::master::V_TopicInfo topic_infos;
-  geometry_msgs::msg::Transform init_pose;
-  std::string robot_name;
-  std::string map_topic;
-  std::string map_updates_topic;
+    // ros::master::V_TopicInfo topic_infos;
+    geometry_msgs::msg::Transform init_pose;
+    std::string robot_name;
+    std::string map_topic;
+    std::string map_updates_topic;
 
-  // ros::master::getTopics(topic_infos);
-  std::map<std::string, std::vector<std::string>> topic_infos = this->get_topic_names_and_types();
+    // ros::master::getTopics(topic_infos);
+    std::map<std::string, std::vector<std::string>> topic_infos = this->get_topic_names_and_types();
 
-  for (const auto& topic_it : topic_infos) {
-    std::string topic_name = topic_it.first;
-    std::vector<std::string> topic_types = topic_it.second;
-    // iterate over all topic types
-    for (const auto& topic_type : topic_types) {
-      // RCLCPP_INFO(logger_, "Topic: %s, type: %s", topic_name.c_str(), topic_type.c_str());
+    for (const auto& topic_it : topic_infos) {
+      std::string topic_name = topic_it.first;
+      std::vector<std::string> topic_types = topic_it.second;
+      // iterate over all topic types
+      for (const auto& topic_type : topic_types) {
+        // RCLCPP_INFO(logger_, "Topic: %s, type: %s", topic_name.c_str(), topic_type.c_str());
 
-      // we check only map topic
-      if (!isRobotMapTopic(topic_name, topic_type)) {
-        continue;
-      }
-    
-      robot_name = robotNameFromTopic(topic_name);
-      if (robots_.count(robot_name)) {
-        // we already know this robot
-        continue;
-      }
+        // we check only map topic
+        if (!isRobotMapTopic(topic_name, topic_type)) {
+          continue;
+        }
 
-      if (have_initial_poses_ && !getInitPose(robot_name, init_pose)) {
-        RCLCPP_WARN(logger_, "Couldn't get initial position for robot [%s]\n"
-                "did you defined parameters map_merge/init_pose_[xyz]? in robot "
-                "namespace? If you want to run merging without known initial "
-                "positions of robots please set `known_init_poses` parameter "
-                "to false. See relevant documentation for details.",
-                robot_name.c_str());
-        continue;
-      }
+        robot_name = robotNameFromTopic(topic_name);
+        if (robots_.count(robot_name)) {
+          // we already know this robot
+          continue;
+        }
 
-      RCLCPP_INFO(logger_, "adding robot [%s] to system", robot_name.c_str());
-      {
-        // We don't lock since because of ROS2 default executor only a callback can run at a time
-        // std::lock_guard<boost::shared_mutex> lock(subscriptions_mutex_);
-        subscriptions_.emplace_front();
-        ++subscriptions_size_;
-      }
+        if (have_initial_poses_ && !getInitPose(robot_name, init_pose)) {
+          RCLCPP_WARN(logger_, "Couldn't get initial position for robot [%s]\n"
+            "did you defined parameters map_merge/init_pose_[xyz]? in robot "
+            "namespace? If you want to run merging without known initial "
+            "positions of robots please set `known_init_poses` parameter "
+            "to false. See relevant documentation for details.",
+            robot_name.c_str());
+          continue;
+        }
 
-      // no locking here. robots_ are used only in this procedure
-      MapSubscription& subscription = subscriptions_.front();
-      robots_.insert({robot_name, &subscription});
-      subscription.initial_pose = init_pose;
+        RCLCPP_INFO(logger_, "adding robot [%s] to system", robot_name.c_str());
+        {
+          // We don't lock since because of ROS2 default executor only a callback can run at a time
+          // std::lock_guard<boost::shared_mutex> lock(subscriptions_mutex_);
+          subscriptions_.emplace_front();
+          ++subscriptions_size_;
+        }
 
-      /* subscribe callbacks */
-      map_topic = ros1_names::append(robot_name, robot_map_topic_);
-      map_updates_topic =
+        // no locking here. robots_ are used only in this procedure
+        MapSubscription& subscription = subscriptions_.front();
+        robots_.insert({ robot_name, &subscription });
+        subscription.initial_pose = init_pose;
+
+        /* subscribe callbacks */
+        map_topic = ros1_names::append(robot_name, robot_map_topic_);
+        map_updates_topic =
           ros1_names::append(robot_name, robot_map_updates_topic_);
-      RCLCPP_INFO(logger_, "Subscribing to MAP topic: %s.", map_topic.c_str());
-      auto map_qos = rclcpp::QoS(rclcpp::KeepLast(50)).transient_local().reliable();
-      subscription.map_sub = this->create_subscription<nav_msgs::msg::OccupancyGrid>(
+        RCLCPP_INFO(logger_, "Subscribing to MAP topic: %s.", map_topic.c_str());
+        auto map_qos = rclcpp::QoS(rclcpp::KeepLast(50)).transient_local().reliable();
+        subscription.map_sub = this->create_subscription<nav_msgs::msg::OccupancyGrid>(
           map_topic, map_qos,
           [this, &subscription](const nav_msgs::msg::OccupancyGrid::SharedPtr msg) {
             fullMapUpdate(msg, subscription);
           });
-      RCLCPP_INFO(logger_, "Subscribing to MAP updates topic: %s.",
-              map_updates_topic.c_str());
-      subscription.map_updates_sub =
+        RCLCPP_INFO(logger_, "Subscribing to MAP updates topic: %s.",
+          map_updates_topic.c_str());
+        subscription.map_updates_sub =
           this->create_subscription<map_msgs::msg::OccupancyGridUpdate>(
-              map_updates_topic, map_qos,
-              [this, &subscription](
-                  const map_msgs::msg::OccupancyGridUpdate::SharedPtr msg) {
+            map_updates_topic, map_qos,
+            [this, &subscription](
+              const map_msgs::msg::OccupancyGridUpdate::SharedPtr msg) {
                 partialMapUpdate(msg, subscription);
-              });
+            });
+      }
     }
   }
-}
 
-/*
- * mapMerging()
- */
-void MapMerge::mapMerging()
-{
-  RCLCPP_DEBUG(logger_, "Map merging started.");
-  RCLCPP_INFO_ONCE(logger_, "Map merging started.");
+  /*
+   * mapMerging()
+   */
+  void MapMerge::mapMerging() {
+    RCLCPP_DEBUG(logger_, "Map merging started.");
+    RCLCPP_INFO_ONCE(logger_, "Map merging started.");
 
-  if (have_initial_poses_) {
-    // TODO: attempt fix for SLAM toolbox: add method for padding grids to same size
+    if (have_initial_poses_) {
+      // TODO: attempt fix for SLAM toolbox: add method for padding grids to same size
 
+      std::vector<nav_msgs::msg::OccupancyGrid::ConstSharedPtr> grids;
+      std::vector<geometry_msgs::msg::Transform> transforms;
+      grids.reserve(subscriptions_size_);
+      {
+        // We don't lock since because of ROS2 default executor only a callback can run
+        // boost::shared_lock<boost::shared_mutex> lock(subscriptions_mutex_);
+        for (auto& subscription : subscriptions_) {
+          // std::lock_guard<std::mutex> s_lock(subscription.mutex);
+
+          grids.push_back(subscription.readonly_map);
+          transforms.push_back(subscription.initial_pose);
+        }
+      }
+
+
+      // we don't need to lock here, because when have_initial_poses_ is true we
+      // will not run concurrently on the pipeline
+      pipeline_.feed(grids.begin(), grids.end());
+      pipeline_.setTransforms(transforms.begin(), transforms.end());
+    }
+
+    // nav_msgs::OccupancyGridPtr merged_map;
+    nav_msgs::msg::OccupancyGrid::SharedPtr merged_map;
+    {
+      std::lock_guard<std::mutex> lock(pipeline_mutex_);
+      merged_map = pipeline_.composeGrids();
+    }
+    if (!merged_map) {
+      // RCLCPP_INFO(logger_, "No map merged");
+      return;
+    }
+
+    RCLCPP_DEBUG(logger_, "all maps merged, publishing");
+    // RCLCPP_INFO(logger_, "all maps merged, publishing");
+    auto now = this->now();
+    merged_map->info.map_load_time = now;
+    merged_map->header.stamp = now;
+    merged_map->header.frame_id = world_frame_;
+
+    rcpputils::assert_true(merged_map->info.resolution > 0.f);
+    merged_map_publisher_->publish(*merged_map);
+  }
+
+  void MapMerge::poseEstimation() {
+    RCLCPP_DEBUG(logger_, "Grid pose estimation started.");
+    RCLCPP_INFO_ONCE(logger_, "Grid pose estimation started.");
     std::vector<nav_msgs::msg::OccupancyGrid::ConstSharedPtr> grids;
-    std::vector<geometry_msgs::msg::Transform> transforms;
     grids.reserve(subscriptions_size_);
+
     {
       // We don't lock since because of ROS2 default executor only a callback can run
       // boost::shared_lock<boost::shared_mutex> lock(subscriptions_mutex_);
       for (auto& subscription : subscriptions_) {
         // std::lock_guard<std::mutex> s_lock(subscription.mutex);
-
         grids.push_back(subscription.readonly_map);
-        transforms.push_back(subscription.initial_pose);
       }
     }
 
+    // Print grids size
+    // RCLCPP_INFO(logger_, "Grids size: %d", grids.size());
 
-    // we don't need to lock here, because when have_initial_poses_ is true we
-    // will not run concurrently on the pipeline
-    pipeline_.feed(grids.begin(), grids.end());
-    pipeline_.setTransforms(transforms.begin(), transforms.end());
-  }
-
-  // nav_msgs::OccupancyGridPtr merged_map;
-  nav_msgs::msg::OccupancyGrid::SharedPtr merged_map;
-  {
     std::lock_guard<std::mutex> lock(pipeline_mutex_);
-    merged_map = pipeline_.composeGrids();
-  }
-  if (!merged_map) {
-    // RCLCPP_INFO(logger_, "No map merged");
-    return;
-  }
-
-  RCLCPP_DEBUG(logger_, "all maps merged, publishing");
-  // RCLCPP_INFO(logger_, "all maps merged, publishing");
-  auto now = this->now();
-  merged_map->info.map_load_time = now;
-  merged_map->header.stamp = now;
-  merged_map->header.frame_id = world_frame_;
-
-  rcpputils::assert_true(merged_map->info.resolution > 0.f);
-  merged_map_publisher_->publish(*merged_map);
-}
-
-void MapMerge::poseEstimation()
-{
-  RCLCPP_DEBUG(logger_, "Grid pose estimation started.");
-  RCLCPP_INFO_ONCE(logger_, "Grid pose estimation started.");
-  std::vector<nav_msgs::msg::OccupancyGrid::ConstSharedPtr> grids;
-  grids.reserve(subscriptions_size_);
-
-  {
-    // We don't lock since because of ROS2 default executor only a callback can run
-    // boost::shared_lock<boost::shared_mutex> lock(subscriptions_mutex_);
-    for (auto& subscription : subscriptions_) {
-      // std::lock_guard<std::mutex> s_lock(subscription.mutex);
-      grids.push_back(subscription.readonly_map);
+    pipeline_.feed(grids.begin(), grids.end());
+    // TODO allow user to change feature type
+    bool success = pipeline_.estimateTransforms(combine_grids::FeatureType::AKAZE,
+      confidence_threshold_);
+    // bool success = pipeline_.estimateTransforms(combine_grids::FeatureType::SURF,
+    //                              confidence_threshold_);
+    // bool success = pipeline_.estimateTransforms(combine_grids::FeatureType::ORB,
+    //                              confidence_threshold_);
+    if (!success) {
+      RCLCPP_INFO(logger_, "No grid poses estimated");
     }
   }
 
-  // Print grids size
-  // RCLCPP_INFO(logger_, "Grids size: %d", grids.size());
-
-  std::lock_guard<std::mutex> lock(pipeline_mutex_);
-  pipeline_.feed(grids.begin(), grids.end());
-  // TODO allow user to change feature type
-  bool success = pipeline_.estimateTransforms(combine_grids::FeatureType::AKAZE,
-                               confidence_threshold_);
-  // bool success = pipeline_.estimateTransforms(combine_grids::FeatureType::SURF,
-  //                              confidence_threshold_);
-  // bool success = pipeline_.estimateTransforms(combine_grids::FeatureType::ORB,
-  //                              confidence_threshold_);
-  if (!success) {
-    RCLCPP_INFO(logger_, "No grid poses estimated");
-  }
-}
-
-// void MapMerge::fullMapUpdate(const nav_msgs::OccupancyGrid::ConstPtr& msg,
-//                              MapSubscription& subscription)
-void MapMerge::fullMapUpdate(const nav_msgs::msg::OccupancyGrid::SharedPtr msg,
-                     MapSubscription& subscription)
-{
-  RCLCPP_DEBUG(logger_, "received full map update");
-  // RCLCPP_INFO(logger_, "received full map update");
-  std::lock_guard<std::mutex> lock(subscription.mutex);
-  if (subscription.readonly_map){
-    // ros2 header .stamp don't support > operator, we need to create them explicitly
-    auto t1 = rclcpp::Time(subscription.readonly_map->header.stamp);
-    auto t2 = rclcpp::Time(msg->header.stamp);
-    if (t1 > t2) {
-      // we have been overrunned by faster update. our work was useless.
-      return;
-    }
-  }
-
-  subscription.readonly_map = msg;
-  subscription.writable_map = nullptr;
-}
-
-// void MapMerge::partialMapUpdate(
-//     const map_msgs::OccupancyGridUpdate::ConstPtr& msg,
-//     MapSubscription& subscription)
-void MapMerge::partialMapUpdate(const map_msgs::msg::OccupancyGridUpdate::SharedPtr msg,
-                        MapSubscription& subscription)
-{
-  RCLCPP_DEBUG(logger_, "received partial map update");
-
-  if (msg->x < 0 || msg->y < 0) {
-    RCLCPP_ERROR(logger_, "negative coordinates, invalid update. x: %d, y: %d", msg->x,
-              msg->y);
-    return;
-  }
-
-  size_t x0 = static_cast<size_t>(msg->x);
-  size_t y0 = static_cast<size_t>(msg->y);
-  size_t xn = msg->width + x0;
-  size_t yn = msg->height + y0;
-
-  nav_msgs::msg::OccupancyGrid::SharedPtr map;
-  nav_msgs::msg::OccupancyGrid::ConstSharedPtr readonly_map;  // local copy
-  {
-    // load maps
+  // void MapMerge::fullMapUpdate(const nav_msgs::OccupancyGrid::ConstPtr& msg,
+  //                              MapSubscription& subscription)
+  void MapMerge::fullMapUpdate(const nav_msgs::msg::OccupancyGrid::SharedPtr msg,
+    MapSubscription& subscription) {
+    RCLCPP_DEBUG(logger_, "received full map update");
+    // RCLCPP_INFO(logger_, "received full map update");
     std::lock_guard<std::mutex> lock(subscription.mutex);
-    map = subscription.writable_map;
-    readonly_map = subscription.readonly_map;
-  }
-
-  if (!readonly_map) {
-    RCLCPP_WARN(logger_, "received partial map update, but don't have any full map to "
-             "update. skipping.");
-    return;
-  }
-
-  // // we don't have partial map to take update, we must copy readonly map and
-  // // update new writable map
-  if (!map) {
-    map.reset(new nav_msgs::msg::OccupancyGrid(*readonly_map));
-  }
-
-  size_t grid_xn = map->info.width;
-  size_t grid_yn = map->info.height;
-
-  if (xn > grid_xn || x0 > grid_xn || yn > grid_yn || y0 > grid_yn) {
-    RCLCPP_WARN(logger_, "received update doesn't fully fit into existing map, "
-             "only part will be copied. received: [%lu, %lu], [%lu, %lu] "
-             "map is: [0, %lu], [0, %lu]",
-             x0, xn, y0, yn, grid_xn, grid_yn);
-  }
-
-  // update map with data
-  size_t i = 0;
-  for (size_t y = y0; y < yn && y < grid_yn; ++y) {
-    for (size_t x = x0; x < xn && x < grid_xn; ++x) {
-      size_t idx = y * grid_xn + x;  // index to grid for this specified cell
-      map->data[idx] = msg->data[i];
-      ++i;
-    }
-  }
-  // update time stamp
-  map->header.stamp = msg->header.stamp;
-
-  {
-    // store back updated map
-    std::lock_guard<std::mutex> lock(subscription.mutex);
-    if (subscription.readonly_map){
+    if (subscription.readonly_map) {
       // ros2 header .stamp don't support > operator, we need to create them explicitly
       auto t1 = rclcpp::Time(subscription.readonly_map->header.stamp);
-      auto t2 = rclcpp::Time(map->header.stamp);
+      auto t2 = rclcpp::Time(msg->header.stamp);
       if (t1 > t2) {
         // we have been overrunned by faster update. our work was useless.
         return;
       }
     }
-    subscription.writable_map = map;
-    subscription.readonly_map = map;
+
+    subscription.readonly_map = msg;
+    subscription.writable_map = nullptr;
   }
-}
 
-std::string MapMerge::robotNameFromTopic(const std::string& topic)
-{
-  return ros1_names::parentNamespace(topic);
-}
+  // void MapMerge::partialMapUpdate(
+  //     const map_msgs::OccupancyGridUpdate::ConstPtr& msg,
+  //     MapSubscription& subscription)
+  void MapMerge::partialMapUpdate(const map_msgs::msg::OccupancyGridUpdate::SharedPtr msg,
+    MapSubscription& subscription) {
+    RCLCPP_DEBUG(logger_, "received partial map update");
 
-/* identifies topic via suffix */
-bool MapMerge::isRobotMapTopic(const std::string topic, std::string type)
-{
-  /* test whether topic is robot_map_topic_ */
-  std::string topic_namespace = ros1_names::parentNamespace(topic);
-  bool is_map_topic = ros1_names::append(topic_namespace, robot_map_topic_) == topic;
+    if (msg->x < 0 || msg->y < 0) {
+      RCLCPP_ERROR(logger_, "negative coordinates, invalid update. x: %d, y: %d", msg->x,
+        msg->y);
+      return;
+    }
 
-  // /* test whether topic contains *anywhere* robot namespace */
-  auto pos = topic.find(robot_namespace_);
-  bool contains_robot_namespace = pos != std::string::npos;
+    size_t x0 = static_cast<size_t>(msg->x);
+    size_t y0 = static_cast<size_t>(msg->y);
+    size_t xn = msg->width + x0;
+    size_t yn = msg->height + y0;
 
-  // /* we support only occupancy grids as maps */
-  bool is_occupancy_grid = type == "nav_msgs/msg/OccupancyGrid";
+    nav_msgs::msg::OccupancyGrid::SharedPtr map;
+    nav_msgs::msg::OccupancyGrid::ConstSharedPtr readonly_map;  // local copy
+    {
+      // load maps
+      std::lock_guard<std::mutex> lock(subscription.mutex);
+      map = subscription.writable_map;
+      readonly_map = subscription.readonly_map;
+    }
 
-  // /* we don't want to subcribe on published merged map */
-  bool is_our_topic = merged_map_publisher_->get_topic_name() == topic;
+    if (!readonly_map) {
+      RCLCPP_WARN(logger_, "received partial map update, but don't have any full map to "
+        "update. skipping.");
+      return;
+    }
 
-  return is_occupancy_grid && !is_our_topic && contains_robot_namespace &&
-         is_map_topic;
-}
+    // // we don't have partial map to take update, we must copy readonly map and
+    // // update new writable map
+    if (!map) {
+      map.reset(new nav_msgs::msg::OccupancyGrid(*readonly_map));
+    }
 
-/*
- * Get robot's initial position
- */
-bool MapMerge::getInitPose(const std::string& name,
-                           geometry_msgs::msg::Transform& pose)
-{
-  std::string merging_namespace = ros1_names::append(name, "map_merge");
-  double yaw = 0.0;
+    size_t grid_xn = map->info.width;
+    size_t grid_yn = map->info.height;
 
-  bool success =
+    if (xn > grid_xn || x0 > grid_xn || yn > grid_yn || y0 > grid_yn) {
+      RCLCPP_WARN(logger_, "received update doesn't fully fit into existing map, "
+        "only part will be copied. received: [%lu, %lu], [%lu, %lu] "
+        "map is: [0, %lu], [0, %lu]",
+        x0, xn, y0, yn, grid_xn, grid_yn);
+    }
+
+    // update map with data
+    size_t i = 0;
+    for (size_t y = y0; y < yn && y < grid_yn; ++y) {
+      for (size_t x = x0; x < xn && x < grid_xn; ++x) {
+        size_t idx = y * grid_xn + x;  // index to grid for this specified cell
+        map->data[idx] = msg->data[i];
+        ++i;
+      }
+    }
+    // update time stamp
+    map->header.stamp = msg->header.stamp;
+
+    {
+      // store back updated map
+      std::lock_guard<std::mutex> lock(subscription.mutex);
+      if (subscription.readonly_map) {
+        // ros2 header .stamp don't support > operator, we need to create them explicitly
+        auto t1 = rclcpp::Time(subscription.readonly_map->header.stamp);
+        auto t2 = rclcpp::Time(map->header.stamp);
+        if (t1 > t2) {
+          // we have been overrunned by faster update. our work was useless.
+          return;
+        }
+      }
+      subscription.writable_map = map;
+      subscription.readonly_map = map;
+    }
+  }
+
+  std::string MapMerge::robotNameFromTopic(const std::string& topic) {
+    return ros1_names::parentNamespace(topic);
+  }
+
+  /* identifies topic via suffix */
+  bool MapMerge::isRobotMapTopic(const std::string topic, std::string type) {
+    /* test whether topic is robot_map_topic_ */
+    std::string topic_namespace = ros1_names::parentNamespace(topic);
+    bool is_map_topic = ros1_names::append(topic_namespace, robot_map_topic_) == topic;
+
+    // /* test whether topic contains *anywhere* robot namespace */
+    auto pos = topic.find(robot_namespace_);
+    bool contains_robot_namespace = pos != std::string::npos;
+
+    // /* we support only occupancy grids as maps */
+    bool is_occupancy_grid = type == "nav_msgs/msg/OccupancyGrid";
+
+    // /* we don't want to subcribe on published merged map */
+    bool is_our_topic = merged_map_publisher_->get_topic_name() == topic;
+
+    return is_occupancy_grid && !is_our_topic && contains_robot_namespace &&
+      is_map_topic;
+  }
+
+  /*
+   * Get robot's initial position
+   */
+  bool MapMerge::getInitPose(const std::string& name,
+    geometry_msgs::msg::Transform& pose) {
+    std::string merging_namespace = ros1_names::append(name, "map_merge");
+    double yaw = 0.0;
+
+    bool success =
       this->get_parameter(ros1_names::append(merging_namespace, "init_pose_x"),
-                      pose.translation.x) &&
+        pose.translation.x) &&
       this->get_parameter(ros1_names::append(merging_namespace, "init_pose_y"),
-                      pose.translation.y) &&
+        pose.translation.y) &&
       this->get_parameter(ros1_names::append(merging_namespace, "init_pose_z"),
-                      pose.translation.z) &&
+        pose.translation.z) &&
       this->get_parameter(ros1_names::append(merging_namespace, "init_pose_yaw"),
-                      yaw);
+        yaw);
 
-  tf2::Quaternion q;
-  q.setEuler(0., 0., yaw);
-  pose.rotation = toMsg(q);
+    tf2::Quaternion q;
+    q.setEuler(0., 0., yaw);
+    pose.rotation = toMsg(q);
 
-  return success;
-}
+    return success;
+  }
 }  // namespace map_merge
 
-int main(int argc, char** argv)
-{
+int main(int argc, char** argv) {
   rclcpp::init(argc, argv);
   // ROS1 code
   // // this package is still in development -- start wil debugging enabled
@@ -445,7 +435,7 @@ int main(int argc, char** argv)
   //                                    ros::console::levels::Debug)) {
   //   ros::console::notifyLoggerLevelsChanged();
   // }
-  
+
   // ROS2 code
   auto node = std::make_shared<map_merge::MapMerge>();
   rclcpp::spin(node);


### PR DESCRIPTION
Custom loggers (obtained with a custom name, e.g. `get_logger("ExploreNode")`) are not linked to the node and therefore the logs are only printed in the terminal and are not published to `/rosout`, so they are not included in ROS bags.

By using the explore_node default logger, the logs are published to `/rosout` and can be included in ROS bags.

Note: I changed the loggers of the explore part but not the map merging part, but I can do it if necessary