### PR TITLE
Replace custom logger by node logger

### DIFF
--- a/explore/include/explore/explore.h
+++ b/explore/include/explore/explore.h
@@ -109,7 +109,6 @@ private:
 
   rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr
       marker_array_publisher_;
-  rclcpp::Logger logger_ = rclcpp::get_logger("ExploreNode");
   tf2_ros::Buffer tf_buffer_;
   tf2_ros::TransformListener tf_listener_;
 

--- a/explore/include/explore/frontier_search.h
+++ b/explore/include/explore/frontier_search.h
@@ -26,16 +26,14 @@ struct Frontier {
 class FrontierSearch
 {
 public:
-  FrontierSearch()
-  {
-  }
+  FrontierSearch() : logger_(rclcpp::get_logger("frontier_search")) {} // Default constructor for the logger
 
   /**
    * @brief Constructor for search task
    * @param costmap Reference to costmap data to search.
    */
   FrontierSearch(nav2_costmap_2d::Costmap2D* costmap, double potential_scale,
-                 double gain_scale, double min_frontier_size);
+                 double gain_scale, double min_frontier_size, rclcpp::Logger logger);
 
   /**
    * @brief Runs search implementation, outward from the start position
@@ -83,6 +81,7 @@ private:
   unsigned int size_x_, size_y_;
   double potential_scale_, gain_scale_;
   double min_frontier_size_;
+  rclcpp::Logger logger_;
 };
 }  // namespace frontier_exploration
 #endif

--- a/explore/src/frontier_search.cpp
+++ b/explore/src/frontier_search.cpp
@@ -14,11 +14,12 @@ using nav2_costmap_2d::NO_INFORMATION;
 
 FrontierSearch::FrontierSearch(nav2_costmap_2d::Costmap2D* costmap,
                                double potential_scale, double gain_scale,
-                               double min_frontier_size)
+                               double min_frontier_size, rclcpp::Logger logger)
   : costmap_(costmap)
   , potential_scale_(potential_scale)
   , gain_scale_(gain_scale)
   , min_frontier_size_(min_frontier_size)
+  , logger_(logger)
 {
 }
 
@@ -30,9 +31,7 @@ FrontierSearch::searchFrom(geometry_msgs::msg::Point position)
   // Sanity check that robot is inside costmap bounds before searching
   unsigned int mx, my;
   if (!costmap_->worldToMap(position.x, position.y, mx, my)) {
-    RCLCPP_ERROR(rclcpp::get_logger("FrontierSearch"), "Robot out of costmap "
-                                                       "bounds, cannot search "
-                                                       "for frontiers");
+    RCLCPP_ERROR(logger_, "[FrontierSearch] Robot out of costmap bounds, cannot search for frontiers");
     return frontier_list;
   }
 
@@ -57,9 +56,7 @@ FrontierSearch::searchFrom(geometry_msgs::msg::Point position)
     bfs.push(clear);
   } else {
     bfs.push(pos);
-    RCLCPP_WARN(rclcpp::get_logger("FrontierSearch"), "Could not find nearby "
-                                                      "clear cell to start "
-                                                      "search");
+    RCLCPP_WARN(logger_, "[FrontierSearch] Could not find nearby clear cell to start search");
   }
   visited_flag[bfs.front()] = true;
 


### PR DESCRIPTION
Custom loggers (obtained with a custom name, e.g. `get_logger("ExploreNode")`) are not linked to the node and therefore the logs are only printed in the terminal and are not published to `/rosout`, so they are not included in ROS bags.

By using the explore_node default logger, the logs are published to `/rosout` and can be included in ROS bags.

Note: I changed the loggers of the explore part but not the map merging part, but I can do it if necessary