### PR TITLE
Deprecate ament_target_dependencies

### DIFF
--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -16,7 +16,7 @@ jobs:
             ros_distribution: humble
           - docker_image: ubuntu:noble
             ros_distribution: jazzy
-          - docker_image: ubuntu:kilted
+          - docker_image: ubuntu:noble
             ros_distribution: kilted
     container:
       image: ${{ matrix.docker_image }}

--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -9,12 +9,15 @@ jobs:
         ros_distribution:
           - humble
           - jazzy
+          - kilted
         include:
           # https://dlu.github.io/ros_clock/index.html
           - docker_image: ubuntu:jammy
             ros_distribution: humble
           - docker_image: ubuntu:noble
             ros_distribution: jazzy
+          - docker_image: ubuntu:kilted
+            ros_distribution: kilted
     container:
       image: ${{ matrix.docker_image }}
     steps:

--- a/explore/CMakeLists.txt
+++ b/explore/CMakeLists.txt
@@ -34,6 +34,7 @@ find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
+find_package(geometry_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
@@ -50,7 +51,6 @@ set(DEPENDENCIES
   sensor_msgs
   tf2
   tf2_ros
-  tf2_geometry_msgs
   nav2_msgs
   nav_msgs
   map_msgs
@@ -87,10 +87,19 @@ target_include_directories(explore PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)
 
+target_link_libraries(explore PUBLIC
+  ${geometry_msgs_TARGETS}
+  ${map_msgs_TARGETS}
+  ${nav2_msgs_TARGETS}
+  ${nav_msgs_TARGETS}
+  ${std_msgs_TARGETS}
+  ${visualization_msgs_TARGETS}
+  nav2_costmap_2d::filters
+  rclcpp::rclcpp
+  tf2::tf2
+  tf2_ros::tf2_ros
+)
 
-target_link_libraries(explore ${rclcpp_LIBRARIES})
-
-ament_target_dependencies(explore ${DEPENDENCIES})
 
 install(TARGETS explore
   DESTINATION lib/${PROJECT_NAME})
@@ -110,12 +119,25 @@ if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
 
   ament_add_gtest(test_explore test/test_explore.cpp)
-  target_link_libraries(test_explore ${catkin_LIBRARIES})
-  ament_target_dependencies(test_explore ${DEPENDENCIES})
 
-  
+  target_link_libraries(test_explore
+    ${geometry_msgs_TARGETS}
+  )
+
 endif()
 
+ament_export_dependencies(
+  geometry_msgs
+  map_msgs
+  nav2_costmap_2d
+  nav2_msgs
+  nav_msgs
+  rclcpp
+  std_msgs
+  tf2
+  tf2_ros
+  visualization_msgs
+)
 
 ament_export_include_directories(include)
 ament_package()

--- a/explore/include/explore/explore.h
+++ b/explore/include/explore/explore.h
@@ -46,13 +46,10 @@
 #include <chrono>
 #include <cmath>
 #include <geometry_msgs/msg/point.hpp>
-#include <memory>
-#include <mutex>
 #include <rclcpp/rclcpp.hpp>
 #include <std_msgs/msg/bool.hpp>
 #include <std_msgs/msg/color_rgba.hpp>
 #include <string>
-#include <vector>
 #include <visualization_msgs/msg/marker_array.hpp>
 
 #include "nav2_msgs/action/navigate_to_pose.hpp"

--- a/explore/package.xml
+++ b/explore/package.xml
@@ -14,16 +14,14 @@
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
-  <depend>ament_cmake</depend>
+  <depend>geometry_msgs</depend>
   <depend>map_msgs</depend>
   <depend>nav2_costmap_2d</depend>
   <depend>nav2_msgs</depend>
   <depend>nav_msgs</depend>
   <depend>rclcpp</depend>
-  <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
   <depend>tf2</depend>
-  <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>visualization_msgs</depend>
 


### PR DESCRIPTION
It's deprecated in Kilted and removed in rolling.